### PR TITLE
fix: update PostgreSQL image in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg15
+        image: postgres:15
         env:
           POSTGRES_PASSWORD: postgres
         ports:


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the CI workflow file. The change updates the Docker image used for the PostgreSQL service.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R19): Changed the PostgreSQL Docker image from `pgvector/pgvector:pg15` to `postgres:15`.